### PR TITLE
Added special handling for internal networks (RFC 1918)

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -4,6 +4,7 @@ threshold = 50
 alert_log = alerts.log
 whitelist = 127.0.0.1, 192.168.1.0/24
 blacklist = 10.0.0.5, 172.16.0.0/16
+internal_ip_action = log  # Options: ignore, log, or check
 
 [abuseipdb] 
 api_key = YOUR_AbuseIPDB_API_KEY_HERE

--- a/sample-logs/test_internal_ips.log
+++ b/sample-logs/test_internal_ips.log
@@ -1,0 +1,13 @@
+# RFC 1918 addresses (internal)
+Jan 1 12:00:01 host sshd[1234]: Failed password for invalid user test from 10.0.0.100 port 22 ssh2
+Jan 1 12:00:02 host sshd[1235]: Failed password for invalid user test from 172.16.5.100 port 22 ssh2
+Jan 1 12:00:03 host sshd[1236]: Failed password for invalid user test from 192.168.2.100 port 22 ssh2
+
+# Whitelisted internal address (assuming 192.168.1.0/24 is in your whitelist)
+Jan 1 12:00:04 host sshd[1237]: Failed password for invalid user test from 192.168.1.100 port 22 ssh2
+
+# Blacklisted internal address (assuming 172.16.0.0/16 is in your blacklist)
+Jan 1 12:00:05 host sshd[1238]: Failed password for invalid user test from 172.16.1.100 port 22 ssh2
+
+# Public IP (for comparison)
+Jan 1 12:00:06 host sshd[1239]: Failed password for invalid user test from 8.8.8.8 port 22 ssh2


### PR DESCRIPTION
Add RFC 1918 private IP address handling

- Added detection for RFC 1918 private IP ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.1.0/16)
- Added configurable handling of internal IPs via 'internal_ip_action' config option:
  - 'ignore': Skip internal IPs
  - 'log': Log internal IPs without checking reputation
  - 'check': Process internal IPs normally
- Added special logging for internal IP alerts
- Maintains priority of existing blacklist/whitelist functionality
- Tested with the added test_internal_ips.log

This enhancement prevents unnecessary API calls for internal addresses while providing flexible configuration options for internal network monitoring.